### PR TITLE
Extended debug

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,8 @@ gout 是go写的http 客户端，为提高工作效率而开发
     - [unix socket](#unix-socket)
     - [http2 doc](#http2-doc)
     - [debug mode](#debug-mode)
+        - [general](#debug-general)
+        - [advanced](#debug-advanced)
     
 
 ## 安装
@@ -478,6 +480,7 @@ func main() {
 }
 ```
 ## debug mode
+### debug general
 该模式主要方便调试用的
 * Debug(true)
 
@@ -495,6 +498,33 @@ func main() {
     if err != nil {
         fmt.Printf("err = %v\n", err)
     }   
+}
+
+```
+### debug advanced
+debug高级模式，可传递函数。下面的例子是如果传递IOS_DEBUG环境变量才输出日志
+```go
+package main
+
+import (
+    "fmt"
+    "github.com/guonaihong/gout"
+    "os"
+)
+
+func IOSDebug() gout.DebugOpt {
+    return gout.DebugFunc(func(o *gout.DebugOption) {
+        if len(os.Getenv("IOS_DEBUG")) > 0 { 
+            o.Debug = true
+        }   
+    })  
+}
+
+func main() {
+
+    s := ""
+    err := gout.GET("127.0.0.1:1234").Debug(IOSDebug()).SetBody("test hello").BindBody(&s).Do()
+    fmt.Printf("err = %v\n", err)
 }
 
 ```

--- a/debug.go
+++ b/debug.go
@@ -10,20 +10,48 @@ import (
 	"strings"
 )
 
-func resetBodyAndPrint(req *http.Request, resp *http.Response) error {
+type DebugOption struct {
+	Write io.Writer
+	Debug bool
+	Color bool
+}
+
+type DebugOpt interface {
+	Apply(*DebugOption)
+}
+
+type DebugFunc func(*DebugOption)
+
+func (f DebugFunc) Apply(o *DebugOption) {
+	f(o)
+}
+
+// 暂时不启用
+func DebugColor() DebugOpt {
+	return DebugFunc(func(o *DebugOption) {
+		o.Color = true
+		o.Write = os.Stdout
+	})
+}
+
+func (do *DebugOption) resetBodyAndPrint(req *http.Request, resp *http.Response) error {
 	all, err := ioutil.ReadAll(resp.Body)
 	if err != nil {
 		return err
 	}
 
 	resp.Body = ioutil.NopCloser(bytes.NewReader(all))
-	err = debugPrint(req, resp)
+	err = do.debugPrint(req, resp)
 	resp.Body = ioutil.NopCloser(bytes.NewReader(all))
 	return err
 }
 
-func debugPrint(req *http.Request, rsp *http.Response) error {
-	var w io.Writer = os.Stdout
+func (do *DebugOption) debugPrint(req *http.Request, rsp *http.Response) error {
+	if do.Write == nil {
+		do.Write = os.Stdout
+	}
+
+	var w io.Writer = do.Write
 
 	path := "/"
 	if len(req.URL.Path) > 0 {
@@ -61,5 +89,7 @@ func debugPrint(req *http.Request, rsp *http.Response) error {
 	}
 
 	_, err := io.Copy(w, rsp.Body)
+
+	fmt.Fprintf(w, "\r\n\r\n")
 	return err
 }

--- a/debug.go
+++ b/debug.go
@@ -77,7 +77,7 @@ func (do *DebugOption) debugPrint(req *http.Request, rsp *http.Response) error {
 			return err
 		}
 
-		if _, err := io.Copy(os.Stdout, b); err != nil {
+		if _, err := io.Copy(w, b); err != nil {
 			return err
 		}
 		fmt.Fprintf(w, "\r\n\r\n")
@@ -88,8 +88,10 @@ func (do *DebugOption) debugPrint(req *http.Request, rsp *http.Response) error {
 		fmt.Fprintf(w, "< %s: %s\r\n", k, strings.Join(v, ","))
 	}
 
+	fmt.Fprintf(w, "\r\n\r\n")
 	_, err := io.Copy(w, rsp.Body)
 
 	fmt.Fprintf(w, "\r\n\r\n")
+
 	return err
 }

--- a/debug_test.go
+++ b/debug_test.go
@@ -49,14 +49,16 @@ func TestResetBodyAndPrintFail(t *testing.T) {
 		},
 	}
 
+	do := DebugOption{}
 	for i, c := range test {
 		req, rsp := c()
-		err := resetBodyAndPrint(req, rsp)
+		err := do.resetBodyAndPrint(req, rsp)
 		assert.Error(t, err, fmt.Sprintf("test index = %d", i))
 	}
 }
 
 func TestResetBodyAndPrint(t *testing.T) {
+
 	test := []func() (*http.Request, *http.Response){
 		func() (*http.Request, *http.Response) {
 			req, _ := http.NewRequest("GET", "/", nil)
@@ -72,9 +74,11 @@ func TestResetBodyAndPrint(t *testing.T) {
 			return req, &rsp
 		},
 	}
+
+	do := DebugOption{}
 	for i, c := range test {
 		req, rsp := c()
-		err := resetBodyAndPrint(req, rsp)
+		err := do.resetBodyAndPrint(req, rsp)
 		assert.NoError(t, err, fmt.Sprintf("test index = %d", i))
 	}
 }

--- a/gout.go
+++ b/gout.go
@@ -7,7 +7,8 @@ import (
 type Gout struct {
 	*http.Client
 	routerGroup
-	debug bool
+
+	opt DebugOption
 }
 
 var DefaultClient = http.Client{}

--- a/group.go
+++ b/group.go
@@ -192,7 +192,6 @@ func (g *routerGroup) WithContext(c context.Context) *routerGroup {
 }
 
 func (g *routerGroup) Debug(d ...interface{}) *routerGroup {
-	fmt.Printf("group option = %p\n", &g.Req.g.opt)
 	for _, v := range d {
 		switch opt := v.(type) {
 		case bool:

--- a/group.go
+++ b/group.go
@@ -191,8 +191,17 @@ func (g *routerGroup) WithContext(c context.Context) *routerGroup {
 	return g
 }
 
-func (g *routerGroup) Debug(debug bool) *routerGroup {
-	g.Req.g.debug = true
+func (g *routerGroup) Debug(d ...interface{}) *routerGroup {
+	fmt.Printf("group option = %p\n", &g.Req.g.opt)
+	for _, v := range d {
+		switch opt := v.(type) {
+		case bool:
+			g.Req.g.opt.Debug = true
+		case DebugOpt:
+			opt.Apply(&g.Req.g.opt)
+		}
+	}
+
 	return g
 }
 

--- a/group_test.go
+++ b/group_test.go
@@ -1015,3 +1015,72 @@ func TestUnixSocket(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, s, "ok")
 }
+
+func setupDebug(t *testing.T) *gin.Engine {
+	r := gin.New()
+
+	r.GET("/", func(c *gin.Context) {
+		all, err := ioutil.ReadAll(c.Request.Body)
+
+		assert.NoError(t, err)
+		c.String(200, string(all))
+	})
+
+	return r
+}
+
+/*
+func TestDebug(t *testing.T) {
+	buf := &bytes.Buffer{}
+
+	router := setupDebug(t)
+	ts := httptest.NewServer(http.HandlerFunc(router.ServeHTTP))
+
+	test := []func() DebugOpt{
+		// 测试打开日志输出
+		func() DebugOpt {
+			return DebugFunc(func(o *DebugOption) {
+				t.Logf("--->1.DebugOption address = %p\n", o)
+				o.Debug = true
+			})
+		},
+
+		// 测试修改输出源
+		func() DebugOpt {
+			return DebugFunc(func(o *DebugOption) {
+				t.Logf("--->2.DebugOption address = %p\n", o)
+				buf.Reset()
+				o.Write = buf
+			})
+		},
+
+		// 测试环境变量
+		func() DebugOpt {
+			return DebugFunc(func(o *DebugOption) {
+				buf.Reset()
+				if len(os.Getenv("IOS_DEBUG")) > 0 {
+					o.Debug = true
+				}
+				o.Write = buf
+			})
+		},
+	}
+
+	s := ""
+	for k, v := range test[:2] {
+		s = ""
+		err := GET(ts.URL).Debug(v()).SetBody(fmt.Sprintf("%d test debug", k)).BindBody(&s).Do()
+		assert.NoError(t, err)
+
+		if k != 0 {
+			assert.NotEqual(t, buf.Len(), 0)
+		}
+		assert.Equal(t, fmt.Sprintf("%d test debug", k), s)
+	}
+
+	err := GET(ts.URL).Debug(true).SetBody("true test debug").BindBody(&s).Do()
+
+	assert.NoError(t, err)
+	assert.Equal(t, s, "true test debug")
+}
+*/

--- a/group_test.go
+++ b/group_test.go
@@ -1029,7 +1029,6 @@ func setupDebug(t *testing.T) *gin.Engine {
 	return r
 }
 
-/*
 func TestDebug(t *testing.T) {
 	buf := &bytes.Buffer{}
 
@@ -1050,6 +1049,7 @@ func TestDebug(t *testing.T) {
 			return DebugFunc(func(o *DebugOption) {
 				t.Logf("--->2.DebugOption address = %p\n", o)
 				buf.Reset()
+				o.Debug = true
 				o.Write = buf
 			})
 		},
@@ -1067,15 +1067,16 @@ func TestDebug(t *testing.T) {
 	}
 
 	s := ""
-	for k, v := range test[:2] {
+	os.Setenv("IOS_DEBUG", "true")
+	for k, v := range test {
 		s = ""
-		err := GET(ts.URL).Debug(v()).SetBody(fmt.Sprintf("%d test debug", k)).BindBody(&s).Do()
+		err := GET(ts.URL).Debug(v()).SetBody(fmt.Sprintf("%d test debug.", k)).BindBody(&s).Do()
 		assert.NoError(t, err)
 
 		if k != 0 {
 			assert.NotEqual(t, buf.Len(), 0)
 		}
-		assert.Equal(t, fmt.Sprintf("%d test debug", k), s)
+		assert.Equal(t, fmt.Sprintf("%d test debug.", k), s)
 	}
 
 	err := GET(ts.URL).Debug(true).SetBody("true test debug").BindBody(&s).Do()
@@ -1083,4 +1084,3 @@ func TestDebug(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, s, "true test debug")
 }
-*/

--- a/req.go
+++ b/req.go
@@ -153,8 +153,9 @@ func (r *Req) Do() (err error) {
 
 	defer resp.Body.Close()
 
-	if r.g.debug {
-		if err := resetBodyAndPrint(req, resp); err != nil {
+	fmt.Printf("r.g.opt = %p\n", &r.g.opt)
+	if r.g.opt.Debug {
+		if err := r.g.opt.resetBodyAndPrint(req, resp); err != nil {
 			return err
 		}
 	}

--- a/req.go
+++ b/req.go
@@ -153,7 +153,6 @@ func (r *Req) Do() (err error) {
 
 	defer resp.Body.Close()
 
-	fmt.Printf("r.g.opt = %p\n", &r.g.opt)
 	if r.g.opt.Debug {
 		if err := r.g.opt.resetBodyAndPrint(req, resp); err != nil {
 			return err


### PR DESCRIPTION
#57 
支持高级debug模式，传递函数当配置
```go
package main

import (
    "fmt"
    "github.com/guonaihong/gout"
    "os"
)

func IOSDebug() gout.DebugOpt {
    return gout.DebugFunc(func(o *gout.DebugOption) {
        if len(os.Getenv("IOS_DEBUG")) > 0 { 
            o.Debug = true
        }   
    })  
}

func main() {

    s := ""
    err := gout.GET("127.0.0.1:1234").Debug(IOSDebug()).SetBody("test hello").BindBody(&s).Do()
    fmt.Printf("err = %v\n", err)
}
```