### PR TITLE
打磨SetJSON接口，新增支持string,[]byte类型

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,8 @@ gout 是go写的http 客户端，为提高工作效率而开发
 * 支持设置 GET/PUT/DELETE/PATH/HEAD/OPTIONS
 * 支持设置请求 http header(可传 struct,map,array,slice 等类型)
 * 支持设置 URL query(可传 struct,map,array,slice,string 等类型)
-* 支持设置 json,xml,yaml 编码到请求 body 里面(SetJSON/SetXML/SetYAML)
+* 支持设置 json 编码到请求 body 里面(可传map, struct, string, []byte 等类型)
+* 支持设置 xml,yaml 编码到请求 body 里面(SetJSON/SetXML/SetYAML)
 * 支持设置 form-data(可传 struct,map,array,slice 等类型)
 * 支持设置 x-www-form-urlencoded(可传 struct,map,array,slice 等类型) 
 * 支持设置 io.Reader，uint/uint8/uint16...int/int8...string...[]byte...float32,float64 至请求 body 里面

--- a/_example/01-color-json.go
+++ b/_example/01-color-json.go
@@ -17,7 +17,7 @@ func server() {
 }
 
 func useMap() {
-	fmt.Printf("\n\n1.=============color json===========\n\n")
+	fmt.Printf("\n\n1.=============color json======map example=====\n\n")
 	err := gout.POST(":8080/colorjson").
 		Debug(true).
 		SetJSON(gout.H{"str": "foo",
@@ -42,7 +42,7 @@ func useStruct() {
 		Null *int   `json:"null"`
 	}
 
-	fmt.Printf("\n\n2.=============color json===========\n\n")
+	fmt.Printf("\n\n2.=============color json======struct example=====\n\n")
 	err := gout.POST(":8080/colorjson").
 		Debug(true).
 		SetJSON(req{Str: "foo",
@@ -56,6 +56,57 @@ func useStruct() {
 	}
 }
 
+var query = `
+{
+  "query": {
+    "bool": {
+      "must": [
+        {
+          "exists": {
+            "field": "voice"
+          }
+        },
+        {
+          "match": {
+              "errcode": 3
+          }
+        },
+        {
+          "range": {
+            "time": {
+              "lt": "2020-01-13T23:16:04+08:00",
+              "gt": "2020-01-13T00:00:00+08:00"
+            }
+          }
+        }
+      ]
+    }
+  }
+}
+`
+
+func useString() {
+	fmt.Printf("\n\n3.=============color json======string example=====\n\n")
+	err := gout.POST(":8080/colorjson").
+		Debug(true).
+		SetJSON(query).Do()
+
+	if err != nil {
+		fmt.Printf("err = %v\n", err)
+	}
+}
+
+func useBytes() {
+	fmt.Printf("\n\n4.=============color json======bytes example=====\n\n")
+	err := gout.POST(":8080/colorjson").
+		Debug(true).
+		SetJSON(query).Do()
+
+	if err != nil {
+		fmt.Printf("err = %v\n", err)
+	}
+}
+
 func main() {
 	go server()
 
@@ -63,4 +114,6 @@ func main() {
 
 	useMap()
 	useStruct()
+	useString()
+	useBytes()
 }

--- a/core/core.go
+++ b/core/core.go
@@ -80,3 +80,13 @@ func CloneRequest(r *http.Request) (*http.Request, error) {
 	r0.Body, err = r.GetBody()
 	return r0, err
 }
+
+func GetBytes(v interface{}) (b []byte, ok bool) {
+	switch d := v.(type) {
+	case []byte:
+		return d, true
+	case string:
+		return StringToBytes(d), true
+	}
+	return nil, false
+}

--- a/core/core_test.go
+++ b/core/core_test.go
@@ -9,6 +9,11 @@ import (
 	"testing"
 )
 
+type testCore struct {
+	need interface{}
+	set  interface{}
+}
+
 func Test_Core_LoopElem(t *testing.T) {
 	s := "hello world"
 	p := &s
@@ -44,11 +49,6 @@ func Test_Core_BytesToString(t *testing.T) {
 	for _, test := range tests {
 		assert.Equal(t, BytesToString(test.set), test.need)
 	}
-}
-
-type testCore struct {
-	need interface{}
-	set  interface{}
 }
 
 func Test_Core_StringToBytes(t *testing.T) {
@@ -97,4 +97,22 @@ func Test_Bench_closeRequest(t *testing.T) {
 
 	// 测试body是否一样
 	assert.Equal(t, b, b3)
+}
+
+func Test_Core_GetBytes(t *testing.T) {
+	type getBytes struct {
+		need []byte
+		set  interface{}
+	}
+
+	tests := []getBytes{
+		{[]byte("ok"), "ok"},
+		{[]byte("ok"), []byte("ok")},
+		{nil, new(int)},
+	}
+
+	for _, test := range tests {
+		v, _ := GetBytes(test.set)
+		assert.Equal(t, test.need, v)
+	}
 }

--- a/encode/json.go
+++ b/encode/json.go
@@ -2,6 +2,7 @@ package encode
 
 import (
 	"encoding/json"
+	"github.com/guonaihong/gout/core"
 	"io"
 )
 
@@ -20,7 +21,14 @@ func NewJSONEncode(obj interface{}) *JSONEncode {
 }
 
 // Encode json encoder
-func (j *JSONEncode) Encode(w io.Writer) error {
+func (j *JSONEncode) Encode(w io.Writer) (err error) {
+	if v, ok := core.GetBytes(j.obj); ok {
+		if json.Valid(v) {
+			_, err = w.Write(v)
+			return err
+		}
+	}
+
 	//encode := json.NewEncoder(w)
 	all, err := json.Marshal(j.obj)
 	if err != nil {

--- a/encode/json_test.go
+++ b/encode/json_test.go
@@ -32,7 +32,8 @@ func TestJSONEncode_Encode(t *testing.T) {
 
 	out := bytes.Buffer{}
 
-	data := []interface{}{need, &need}
+	s := `{"I" : 100, "F" : 3.14, "S":"test encode json"}`
+	data := []interface{}{need, &need, s, []byte(s)}
 	for _, v := range data {
 		j := NewJSONEncode(v)
 		out.Reset()

--- a/version.go
+++ b/version.go
@@ -1,4 +1,4 @@
 package gout
 
 // Version show version
-const Version = "v0.0.7"
+const Version = "v0.0.8-dev.2020.1.20"


### PR DESCRIPTION
see #164
在v0.0.8版本写法如下
```go
func useString() {
    fmt.Printf("\n\n3.=============color json======string example=====\n\n")
    err := gout.POST(":8080/colorjson").
        Debug(true).
        SetJSON(query).Do()

    if err != nil {
        fmt.Printf("err = %v\n", err)
    }   
}
```
同样的代码v0.0.7版本写法如下。
```go
func useString() {
    fmt.Printf("\n\n3.=============color json======string example=====\n\n")
    err := gout.POST(":8080/colorjson").
        Debug(true).
        SetHeader(gout.H{"Content-Type": "application/json"}).
        SetBody(query).Do()

    if err != nil {
        fmt.Printf("err = %v\n", err)
    }   
}
```