### PR TITLE
新增Filter和Export函数简写形式

### DIFF
--- a/_example/19a-retry.go
+++ b/_example/19a-retry.go
@@ -1,0 +1,22 @@
+package main
+
+import (
+	"fmt"
+	"github.com/guonaihong/gout"
+	"time"
+)
+
+func main() {
+	err := gout.HEAD("127.0.0.1:8080").
+		Debug(true).                      //打开debug模式
+		Filter().                         //打开过滤器.Filter()的简写是.F()
+		Retry().                          //打开重试模式
+		Attempt(5).                       //最多重试5次
+		WaitTime(500 * time.Millisecond). //基本等待时间
+		MaxWaitTime(3 * time.Second).     //最长等待时间
+		Do()
+
+	if err != nil {
+		fmt.Printf("err = %v\n", err)
+	}
+}

--- a/dataflow/dataflow.go
+++ b/dataflow/dataflow.go
@@ -294,9 +294,19 @@ func (df *DataFlow) Filter() *filter {
 	return &filter{df: df}
 }
 
+// F filter function, use this function to turn on the filter function
+func (df *DataFlow) F() *filter {
+	return df.Filter()
+}
+
 // Export filter function, use this function to turn on the filter function
 func (df *DataFlow) Export() *export {
 	return &export{df: df}
+}
+
+// E filter function, use this function to turn on the filter function
+func (df *DataFlow) E() *export {
+	return df.Export()
 }
 
 func (df *DataFlow) SetGout(out *Gout) {

--- a/dataflow/dataflow_test.go
+++ b/dataflow/dataflow_test.go
@@ -1347,3 +1347,16 @@ func Test_DataFlow_Bind(t *testing.T) {
 		assert.Error(t, e)
 	}
 }
+
+func Test_DataFlow_Fileter_Export(t *testing.T) {
+	tests := []interface{}{
+		New().Filter(),
+		New().F(),
+		New().Export(),
+		New().E(),
+	}
+
+	for _, test := range tests {
+		assert.NotNil(t, test)
+	}
+}


### PR DESCRIPTION
see #168
在v0.0.8支持如下Filter和Export函数简写。类似shell长短选项的做法。

### Fileter简写是F
```go
func main() {
	err := gout.HEAD("127.0.0.1:8080").
		Debug(true).                      //打开debug模式
		F().                              //打开过滤器
		Retry().                          //打开重试模式
		Attempt(5).                       //最多重试5次
		WaitTime(500 * time.Millisecond). //基本等待时间
		MaxWaitTime(3 * time.Second).     //最长等待时间
		Do()

	if err != nil {
		fmt.Printf("err = %v\n", err)
	}
}
```
### Export简写是E
```go
package main

import (
    "fmt"
    "github.com/guonaihong/gout"
)

func main() {
    // 1.formdata
    err := gout.GET(":1234").
        SetForm(gout.A{"text", "good", "mode", "A", "voice", gout.FormFile("./t8.go")}).
        E().Curl().Do()
    // output:
    // curl -X GET -F "text=good" -F "mode=A" -F "voice=@./voice" "http://127.0.0.1:1234"

    fmt.Printf("%v\n", err)
}
```