### PR TITLE
打磨SetXML函数

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,8 @@ gout 是go写的http 客户端，为提高工作效率而开发
 * 支持设置请求 http header(可传 struct,map,array,slice 等类型)
 * 支持设置 URL query(可传 struct,map,array,slice,string 等类型)
 * 支持设置 json 编码到请求 body 里面(可传map, struct, string, []byte 等类型)
-* 支持设置 xml,yaml 编码到请求 body 里面(SetJSON/SetXML/SetYAML)
+* 支持设置 xml 编码到请求 body 里面(可传struct, string, []byte 等类型)
+* 支持设置 yaml 编码到请求 body 里面(SetJSON/SetXML/SetYAML)
 * 支持设置 form-data(可传 struct,map,array,slice 等类型)
 * 支持设置 x-www-form-urlencoded(可传 struct,map,array,slice 等类型) 
 * 支持设置 io.Reader，uint/uint8/uint16...int/int8...string...[]byte...float32,float64 至请求 body 里面
@@ -260,6 +261,8 @@ func main() {
 
 ```
 ### SetQuery支持的更多数据类型
+<details>
+
 ```go
 package main
 
@@ -318,6 +321,8 @@ SetQuery(&testQuery{CheckIn:2019-06-18, CheckOut:2019-06-18})
 // ?active=enable&action=drop
 SetQuery([]string{"active", "enable", "action", "drop"})`
 ```
+
+</details>
 
 ## http header
 #### Set request header
@@ -421,6 +426,8 @@ func main() {
 
 ```
 ### SetHeader和BindHeader支持的更多类型
+<details>
+
 ```go
 package main
 
@@ -452,6 +459,8 @@ func main() {
 }
 
 ```
+
+
 * BindHeader支持的类型有
 结构体
 ```go
@@ -488,6 +497,8 @@ SetHeader(&testHeader{CheckIn:2019-06-18, CheckOut:2019-06-18})
 // -H active:enable -H action:drop
 SetHeader([]string{"active", "enable", "action", "drop"})
 ```
+
+</details>
 
 ## http body
 ### body

--- a/_example/11-xml.go
+++ b/_example/11-xml.go
@@ -28,11 +28,8 @@ func server() {
 	router.Run()
 }
 
-func main() {
+func useStruct() {
 	var rsp data
-	go server()
-	time.Sleep(time.Millisecond * 500) //sleep下等服务端真正起好
-
 	code := 200
 
 	err := gout.POST(":8080/test.xml").
@@ -45,4 +42,45 @@ func main() {
 	if err != nil || code != 200 {
 		fmt.Printf("%v:%d\n", err, code)
 	}
+}
+
+func useString() {
+	var rsp data
+	code := 200
+
+	err := gout.POST(":8080/test.xml").
+		Debug(true).
+		SetXML(`<data><id>3</id><Data>test data</Data></data>`).
+		BindXML(&rsp).
+		Code(&code).
+		Do()
+
+	if err != nil || code != 200 {
+		fmt.Printf("%v:%d\n", err, code)
+	}
+}
+
+func useBytes() {
+	var rsp data
+	code := 200
+
+	err := gout.POST(":8080/test.xml").
+		Debug(true).
+		SetXML([]byte(`<data><id>3</id><Data>test data</Data></data>`)).
+		BindXML(&rsp).
+		Code(&code).
+		Do()
+
+	if err != nil || code != 200 {
+		fmt.Printf("%v:%d\n", err, code)
+	}
+}
+
+func main() {
+	go server()
+	time.Sleep(time.Millisecond * 500) //sleep下等服务端真正起好
+
+	useStruct()
+	useString()
+	useBytes()
 }

--- a/encode/json.go
+++ b/encode/json.go
@@ -2,9 +2,12 @@ package encode
 
 import (
 	"encoding/json"
+	"errors"
 	"github.com/guonaihong/gout/core"
 	"io"
 )
+
+var ErrNotJSON = errors.New("Not json data")
 
 // JSONEncode json encoder structure
 type JSONEncode struct {
@@ -23,10 +26,11 @@ func NewJSONEncode(obj interface{}) *JSONEncode {
 // Encode json encoder
 func (j *JSONEncode) Encode(w io.Writer) (err error) {
 	if v, ok := core.GetBytes(j.obj); ok {
-		if json.Valid(v) {
-			_, err = w.Write(v)
-			return err
+		if b := json.Valid(v); !b {
+			return ErrNotJSON
 		}
+		_, err = w.Write(v)
+		return err
 	}
 
 	//encode := json.NewEncoder(w)

--- a/encode/json_test.go
+++ b/encode/json_test.go
@@ -48,7 +48,7 @@ func TestJSONEncode_Encode(t *testing.T) {
 	}
 
 	// test fail
-	for _, v := range []interface{}{func() {}} {
+	for _, v := range []interface{}{func() {}, `{"query":"value"`} {
 		j := NewJSONEncode(v)
 		out.Reset()
 		err := j.Encode(&out)

--- a/encode/xml.go
+++ b/encode/xml.go
@@ -1,9 +1,14 @@
 package encode
 
 import (
+	"bytes"
 	"encoding/xml"
+	"errors"
+	"github.com/guonaihong/gout/core"
 	"io"
 )
+
+var ErrNotXML = errors.New("Not xml data")
 
 // XMLEncode xml encoder structure
 type XMLEncode struct {
@@ -20,7 +25,16 @@ func NewXMLEncode(obj interface{}) *XMLEncode {
 }
 
 // Encode xml encoder
-func (x *XMLEncode) Encode(w io.Writer) error {
+func (x *XMLEncode) Encode(w io.Writer) (err error) {
+	if v, ok := core.GetBytes(x.obj); ok {
+		if b := XMLValid(v); !b {
+			return ErrNotXML
+		}
+
+		_, err = w.Write(v)
+		return err
+	}
+
 	encode := xml.NewEncoder(w)
 	return encode.Encode(x.obj)
 }
@@ -28,4 +42,19 @@ func (x *XMLEncode) Encode(w io.Writer) error {
 // Name xml Encoder name
 func (x *XMLEncode) Name() string {
 	return "xml"
+}
+
+func XMLValid(b []byte) bool {
+	dec := xml.NewDecoder(bytes.NewBuffer(b))
+	for {
+		_, err := dec.Token()
+		if err != nil {
+			if err == io.EOF {
+				break
+			}
+			return false
+		}
+	}
+
+	return true
 }

--- a/encode/xml_test.go
+++ b/encode/xml_test.go
@@ -31,7 +31,10 @@ func TestXMLEncode_Encode(t *testing.T) {
 
 	out := bytes.Buffer{}
 
-	data := []interface{}{need, &need}
+	x := `
+<testXML><i>100</i><f>3.14</f><s>test encode xml</s></testXML>
+	`
+	data := []interface{}{need, &need, x}
 	for _, v := range data {
 		x := NewXMLEncode(v)
 		out.Reset()
@@ -43,5 +46,13 @@ func TestXMLEncode_Encode(t *testing.T) {
 		err := xml.Unmarshal(out.Bytes(), &got)
 		assert.NoError(t, err)
 		assert.Equal(t, got, need)
+	}
+
+	// test fail
+	for _, v := range []interface{}{`<testxml>`} {
+		x := NewXMLEncode(v)
+		out.Reset()
+		err := x.Encode(&out)
+		assert.Error(t, err)
 	}
 }


### PR DESCRIPTION
看 #170 
打磨SetXML函数，支持string,[]byte格式数据。
在v0.0.8版本写法如下
```go
func useString() {
	var rsp data
	code := 200

	err := gout.POST(":8080/test.xml").
		Debug(true).
		SetXML(`<data><id>3</id><Data>test data</Data></data>`).
		BindXML(&rsp).
		Code(&code).
		Do()

	if err != nil || code != 200 {
		fmt.Printf("%v:%d\n", err, code)
	}
}
```
同样的代码v0.0.7版本写法如下。
```go
func useString() {
    var rsp data
    code := 200

    err := gout.POST(":8080/test.xml").
        Debug(true).
        SetHeader(gout.H{"Content-Type": "application/xml"}).
        SetBody(`<data><id>3</id><Data>test data</Data></data>`).
        BindXML(&rsp).
	Code(&code).
        Do()

    if err != nil {
        fmt.Printf("err = %v\n", err)
    }   
}
```