### PR TITLE
增强SetYAML函数

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,10 +13,10 @@ gout 是go写的http 客户端，为提高工作效率而开发
 * 支持设置 GET/PUT/DELETE/PATH/HEAD/OPTIONS
 * 支持设置请求 http header(可传 struct,map,array,slice 等类型)
 * 支持设置 URL query(可传 struct,map,array,slice,string 等类型)
-* 支持设置 json 编码到请求 body 里面(可传map, struct, string, []byte 等类型)
+* 支持设置 json 编码到请求 body 里面(可传struct, map, string, []byte 等类型)
 * 支持设置 xml 编码到请求 body 里面(可传struct, string, []byte 等类型)
-* 支持设置 yaml 编码到请求 body 里面(SetJSON/SetXML/SetYAML)
-* 支持设置 form-data(可传 struct,map,array,slice 等类型)
+* 支持设置 yaml 编码到请求 body 里面(可传struct, map, string, []byte 等类型)
+* 支持设置 form-data(可传 struct, map, array, slice 等类型)
 * 支持设置 x-www-form-urlencoded(可传 struct,map,array,slice 等类型) 
 * 支持设置 io.Reader，uint/uint8/uint16...int/int8...string...[]byte...float32,float64 至请求 body 里面
 * 支持解析响应body里面的json,xml,yaml至结构体里(BindJSON/BindXML/BindYAML)

--- a/_example/12-yaml.go
+++ b/_example/12-yaml.go
@@ -12,6 +12,86 @@ type data struct {
 	Data string `json:"data xml:"data" yaml:"data"`
 }
 
+func useStruct() {
+	var rsp data
+	code := 200
+
+	err := gout.POST(":8080/test.yaml").
+		Debug(true).
+		SetYAML(data{Id: 3, Data: "test data"}).
+		BindYAML(&rsp).
+		Code(&code).
+		Do()
+
+	if err != nil || code != 200 {
+		fmt.Printf("%v:%d\n", err, code)
+	}
+}
+
+func useMap() {
+	var rsp data
+	code := 200
+
+	err := gout.POST(":8080/test.yaml").
+		Debug(true).
+		SetYAML(gout.H{"id": 3, "data": "test data"}).
+		BindYAML(&rsp).
+		Code(&code).
+		Do()
+
+	if err != nil || code != 200 {
+		fmt.Printf("%v:%d\n", err, code)
+	}
+}
+
+func useString() {
+	var rsp data
+	code := 200
+
+	err := gout.POST(":8080/test.yaml").
+		Debug(true).
+		SetYAML(`
+id: 3
+data: test data
+`).
+		BindYAML(&rsp).
+		Code(&code).
+		Do()
+
+	if err != nil || code != 200 {
+		fmt.Printf("%v:%d\n", err, code)
+	}
+}
+
+func useBytes() {
+	var rsp data
+	code := 200
+
+	err := gout.POST(":8080/test.yaml").
+		Debug(true).
+		SetYAML([]byte(`
+id: 3
+data: test data
+`)).
+		BindYAML(&rsp).
+		Code(&code).
+		Do()
+
+	if err != nil || code != 200 {
+		fmt.Printf("%v:%d\n", err, code)
+	}
+}
+
+func main() {
+	go server()
+	time.Sleep(time.Millisecond * 500) //sleep下等服务端真正起好
+
+	useStruct()
+	useMap()
+	useString()
+	useBytes()
+}
+
 func server() {
 	router := gin.Default()
 
@@ -26,23 +106,4 @@ func server() {
 	})
 
 	router.Run()
-}
-
-func main() {
-	var rsp data
-	go server()
-	time.Sleep(time.Millisecond * 500) //sleep下等服务端真正起好
-
-	code := 200
-
-	err := gout.POST(":8080/test.yaml").
-		Debug(true).
-		SetYAML(data{Id: 3, Data: "test data"}).
-		BindYAML(&rsp).
-		Code(&code).
-		Do()
-
-	if err != nil || code != 200 {
-		fmt.Printf("%v:%d\n", err, code)
-	}
 }

--- a/dataflow/req.go
+++ b/dataflow/req.go
@@ -115,6 +115,7 @@ func (r *Req) addContextType(req *http.Request) {
 		case "xml":
 			req.Header.Add("Content-Type", "application/xml")
 		case "yaml":
+			req.Header.Add("Content-Type", "application/x-yaml")
 		case "www-form":
 			req.Header.Add("Content-Type", "application/x-www-form-urlencoded")
 		}

--- a/encode/yaml.go
+++ b/encode/yaml.go
@@ -1,9 +1,13 @@
 package encode
 
 import (
+	"errors"
+	"github.com/guonaihong/gout/core"
 	"gopkg.in/yaml.v2"
 	"io"
 )
+
+var ErrNotYAML = errors.New("Not yaml data")
 
 // YAMLEncode yaml encoder structure
 type YAMLEncode struct {
@@ -20,7 +24,14 @@ func NewYAMLEncode(obj interface{}) *YAMLEncode {
 }
 
 // Encode yaml encoder
-func (y *YAMLEncode) Encode(w io.Writer) error {
+func (y *YAMLEncode) Encode(w io.Writer) (err error) {
+	if v, ok := core.GetBytes(y.obj); ok {
+		if b := YAMLValid(v); !b {
+			return ErrNotYAML
+		}
+		_, err = w.Write(v)
+		return err
+	}
 	encode := yaml.NewEncoder(w)
 	return encode.Encode(y.obj)
 }
@@ -28,4 +39,15 @@ func (y *YAMLEncode) Encode(w io.Writer) error {
 // Name yaml Encoder name
 func (y *YAMLEncode) Name() string {
 	return "yaml"
+}
+
+func YAMLValid(b []byte) bool {
+	var m map[string]interface{}
+
+	err := yaml.Unmarshal(b, &m)
+	if err != nil {
+		return false
+	}
+
+	return true
 }

--- a/encode/yaml_test.go
+++ b/encode/yaml_test.go
@@ -31,7 +31,11 @@ func TestYAMLEncode_Encode(t *testing.T) {
 
 	out := bytes.Buffer{}
 
-	data := []interface{}{need, &need}
+	s := `
+i: 100
+f: 3.14
+s: test encode yaml`
+	data := []interface{}{need, &need, s, []byte(s)}
 	for _, v := range data {
 		x := NewYAMLEncode(v)
 		out.Reset()
@@ -43,5 +47,13 @@ func TestYAMLEncode_Encode(t *testing.T) {
 		err := yaml.Unmarshal(out.Bytes(), &got)
 		assert.NoError(t, err)
 		assert.Equal(t, got, need)
+	}
+
+	// test fail
+	for _, v := range []interface{}{`I:100 {}`} {
+		y := NewYAMLEncode(v)
+		out.Reset()
+		err := y.Encode(&out)
+		assert.Error(t, err)
 	}
 }


### PR DESCRIPTION
#175 
修改SetYAML函数，支持string,[]byte格式数据。
在v0.0.8版本写法如下
```go
func useString() {
    var rsp data
    code := 200 

    err := gout.POST(":8080/test.yaml").
        Debug(true).
        SetYAML(`
id: 3
data: test data
`).
        BindYAML(&rsp).
        Code(&code).
        Do()

    if err != nil || code != 200 {
        fmt.Printf("%v:%d\n", err, code)
    }
}
```
同样的代码v0.0.7版本写法如下。
```go
func useString() {
    var rsp data
    code := 200 

    err := gout.POST(":8080/test.yaml").
        Debug(true).
        SetHeader(gout.H{"Content-Type": "application/x-yaml"}).
        SetBody(`
id: 3
data: test data
`).
        BindYAML(&rsp).
        Code(&code).
        Do()

    if err != nil || code != 200 {
        fmt.Printf("%v:%d\n", err, code)
    }
}
```