### PR TITLE
增强retry过滤器-支持回调函数

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ gout 是go写的http 客户端，为提高工作效率而开发
 		- [Custom benchmark functions](#Custom-benchmark-functions)
 	- [retry backoff](#retry-backoff)
 		- [Specify the retry conditions, when equal to a certain http code](#retry-conditions-httpcode)
-		- [Specify retry conditions. The default URL cannot be accessed. Use the backup URL](#retry-conditions-backurl)
+		- [Specify retry conditions. The default URL cannot be accessed. Use the backup URL](#retry-conditions-backupurl)
 	- [import](#import)
 		- [send raw http request](#send-raw-http-request)
 	- [export](#export)

--- a/README.md
+++ b/README.md
@@ -1415,7 +1415,7 @@ func useRetryFuncCode() {
 ```
 
 ### retry conditions backupurl
-指定条件进行重试，这里的例子是默认url不能访问，使用backup url进行访问。
+指定条件进行重试，这里的例子是默认url不能访问，使用backup url进行访问
 [完整代码](_example/19b-retry-customize-backup.go)
 ```go
 package main

--- a/_example/19a-retry.go
+++ b/_example/19a-retry.go
@@ -3,11 +3,14 @@ package main
 import (
 	"fmt"
 	"github.com/guonaihong/gout"
+	"github.com/guonaihong/gout/core"
 	"time"
 )
 
 func main() {
-	err := gout.HEAD("127.0.0.1:8080").
+	// 获取一个没有绑定服务的端口
+	port := core.GetNoPortExists()
+	err := gout.HEAD("127.0.0.1:" + port).
 		Debug(true).                      //打开debug模式
 		Filter().                         //打开过滤器.Filter()的简写是.F()
 		Retry().                          //打开重试模式

--- a/_example/19b-retry-customize-backup.go
+++ b/_example/19b-retry-customize-backup.go
@@ -1,0 +1,43 @@
+package main
+
+import (
+	"fmt"
+	"github.com/gin-gonic/gin"
+	"github.com/guonaihong/gout"
+	"github.com/guonaihong/gout/core"
+	"github.com/guonaihong/gout/filter"
+	"time"
+)
+
+func server() {
+	router := gin.New()
+	router.GET("/", func(c *gin.Context) {
+		c.JSON(200, gin.H{"result": "test ok"})
+	})
+
+	router.Run(":1234")
+}
+
+func useRetryFunc() {
+	// 获取一个没有服务绑定的端口
+	port := core.GetNoPortExists()
+	s := ""
+
+	err := gout.GET(":" + port).Debug(true).BindBody(&s).F().
+		Retry().Attempt(3).WaitTime(time.Millisecond * 10).MaxWaitTime(time.Millisecond * 50).
+		Func(func(c *gout.Context) error {
+			if c.Error != nil {
+				c.SetHost(":1234") //必须是存在的端口
+				return filter.ErrRetry
+			}
+			return nil
+
+		}).Do()
+	fmt.Printf("err = %v\n", err)
+}
+
+func main() {
+	go server()
+	time.Sleep(time.Millisecond * 200)
+	useRetryFunc()
+}

--- a/_example/19c-retry-httpcode.go
+++ b/_example/19c-retry-httpcode.go
@@ -1,0 +1,50 @@
+package main
+
+import (
+	"fmt"
+	"github.com/gin-gonic/gin"
+	"github.com/guonaihong/gout"
+	"github.com/guonaihong/gout/filter"
+	"time"
+)
+
+var first bool
+
+// mock 服务端函数
+func server() {
+	router := gin.New()
+
+	router.GET("/code", func(c *gin.Context) {
+		if first {
+			c.JSON(209, gout.H{"resutl": "1.return 209"})
+			first = false
+		} else {
+			c.JSON(200, gout.H{"resut": "2.return 200"})
+		}
+	})
+
+	router.Run()
+}
+
+func useRetryFuncCode() {
+	s := ""
+	err := gout.GET(":8080/code").Debug(true).BindBody(&s).F().
+		Retry().Attempt(3).WaitTime(time.Millisecond * 10).MaxWaitTime(time.Millisecond * 50).
+		Func(func(c *gout.Context) error {
+			if c.Error != nil || c.Code == 209 {
+				return filter.ErrRetry
+			}
+
+			return nil
+
+		}).Do()
+
+	fmt.Printf("err = %v\n", err)
+}
+
+func main() {
+	first = true
+	go server()
+	time.Sleep(time.Millisecond * 200)
+	useRetryFuncCode()
+}

--- a/core/port.go
+++ b/core/port.go
@@ -1,0 +1,21 @@
+package core
+
+import (
+	"fmt"
+	"net"
+)
+
+// 获取没有绑定服务的端口
+func GetNoPortExists() string {
+	startPort := 1000 //1000以下的端口很多时间需要root权限才能使用
+	for port := startPort; port < 65535; port++ {
+		l, err := net.Listen("tcp", fmt.Sprintf("0.0.0.0:%d", port))
+		if err != nil {
+			continue
+		}
+		l.Close()
+		return fmt.Sprintf("%d", port)
+	}
+
+	return "0"
+}

--- a/core/port_test.go
+++ b/core/port_test.go
@@ -1,0 +1,18 @@
+package core
+
+import (
+	"fmt"
+	"github.com/stretchr/testify/assert"
+	"net"
+	"testing"
+)
+
+func TestGetNoPortExists(t *testing.T) {
+	port := GetNoPortExists()
+	l, err := net.Listen("tcp", fmt.Sprintf("0.0.0.0:%s", port))
+	assert.NoError(t, err)
+	if l != nil {
+		l.Close()
+	}
+
+}

--- a/dataflow/context.go
+++ b/dataflow/context.go
@@ -2,7 +2,8 @@ package dataflow
 
 // Context struct
 type Context struct {
-	Code int //http code
+	Code  int //http code
+	Error error
 
 	*DataFlow
 }

--- a/dataflow/filter_test.go
+++ b/dataflow/filter_test.go
@@ -53,9 +53,15 @@ func (t *testRetry) Attempt(attempt int) Retry {
 func (t *testRetry) WaitTime(waitTime time.Duration) Retry {
 	return t
 }
+
 func (t *testRetry) MaxWaitTime(maxWaitTime time.Duration) Retry {
 	return t
 }
+
+func (t *testRetry) Func(func(c *Context) error) Retry {
+	return t
+}
+
 func (t *testRetry) Do() error {
 	return nil
 }

--- a/dataflow/interface.go
+++ b/dataflow/interface.go
@@ -24,6 +24,7 @@ type Retry interface {
 	Attempt(attempt int) Retry
 	WaitTime(waitTime time.Duration) Retry
 	MaxWaitTime(maxWaitTime time.Duration) Retry
+	Func(func(c *Context) error) Retry
 	Do() error
 }
 


### PR DESCRIPTION
issue #166 
增强retry过滤器，可以支持多种条件重试。比如http code码，比如某个url不能访问，使用备用url地址。
伪代码如下。

* 使用http code作为重试条件
```go
package main

import (
	"fmt"
	"github.com/guonaihong/gout"
	"github.com/guonaihong/gout/filter"
	"time"
)

func main() {
	err := gout.GET(url).SetJSON(gout.H{"key": "val"}).
		F(). //打开过滤器函数 是.Filter()的简写
		Retry().Attempt(3).MaxWaitTime(3 * time.Second).WaitTime(500 * time.Second).
		Func(func(c *gout.Context) error {
			switch c.Code {
			case 209: //有些服务返回209表示资源暂时不可用，客户端需要再重试几次
				return filter.ErrRetry
			}
		}).Do()

	fmt.Printf("err = %v\n", err)
}

```

* url连接不上，使用backupURL进行连接
```go
package main

import (
	"fmt"
	"github.com/guonaihong/gout"
	"github.com/guonaihong/gout/core"
	"github.com/guonaihong/gout/filter"
	"time"
)
func useRetryFunc() {
	// 获取一个没有服务绑定的端口
	port := core.GetNoPortExists()
	s := ""

	err := gout.GET(":" + port).Debug(true).BindBody(&s).F().
		Retry().Attempt(3).WaitTime(time.Millisecond * 10).MaxWaitTime(time.Millisecond * 50).
		Func(func(c *gout.Context) error {
			if c.Error != nil {
				c.SetHost(":1234") //必须是存在的端口
				return filter.ErrRetry
			}
			return nil

		}).Do()
	fmt.Printf("err = %v\n", err)
}
```