### PR TITLE
新增关闭3xx自动跳转的全局配置

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,8 +89,9 @@ gout 是go写的http 客户端，为提高工作效率而开发
 	- [Using chunked data format](#Using-chunked-data-format)
 	- [Global configuration](#Global-configuration)
 		- [Insecure skip verify](#insecure-skip-verify)
+		- [Turn off 3xx status code automatic jump](#Turn-off-3xx-status-code-automatic-jump)
 		- [Null values are also serialized](#Null-values-are-also-serialized)
-		- [Global set timeout](#global-set-timeout)
+		- [set timeout](#set-timeout)
  - [Unique features](#Unique-features)
     - [forward gin data](#forward-gin-data)
 
@@ -1633,6 +1634,23 @@ func main() {
 	}
 }
 ```
+## Turn off 3xx status code automatic jump
+golang client库默认遇到301的状态码会自动跳转重新发起新请求, 你希望关闭这种默认形为, 那就使用下面的功能
+```go
+import (
+	"github.com/guonaihong/gout"
+)
+
+func main() {
+	// globalWithOpt里面包含连接池, 这是一个全局可复用的对象, 一个进程里面可能只需创建1个
+	globalWithOpt := gout.NewWithOpt(gout.WithClose3xxJump())
+	err := globalWithOpt.GET("url").Do()
+	if err != nil {
+		fmt.Printf("err = %v\n" ,err)
+		return
+	}
+}
+```
 
 ## Null values are also serialized
 ```go
@@ -1668,7 +1686,7 @@ gout.GET(url).Debug(true).SetQuery(query).SetHeader(header).BindBody(&body).Do()
 ```
 默认会删除，```authid```等空值，使用gout.NotIgnoreEmpty()接口，空value不会删除
 
-## global set timeout
+##  set timeout
 
 设置全局超时时间。可以简化一些代码。在使用全局配置默认你已经了解它会带来的一些弊端.
 ```go

--- a/gout_newopt_with_3xx_test.go
+++ b/gout_newopt_with_3xx_test.go
@@ -1,0 +1,49 @@
+package gout
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/assert"
+)
+
+func createClose302() *httptest.Server {
+	r := gin.New()
+	r.GET("/302", func(c *gin.Context) {
+		c.String(200, "done")
+	})
+
+	return httptest.NewServer(http.HandlerFunc(r.ServeHTTP))
+}
+
+func createClose301(url string) *httptest.Server {
+	r := gin.New()
+	r.GET("/301", func(c *gin.Context) {
+		c.Redirect(302, url+"/302")
+	})
+
+	return httptest.NewServer(http.HandlerFunc(r.ServeHTTP))
+}
+
+func Test_Close3xx_True(t *testing.T) {
+	ts := createClose301("")
+
+	req := NewWithOpt(WithClose3xxJump())
+	got := ""
+	err := req.GET(ts.URL + "/301").BindBody(&got).Do()
+	assert.NoError(t, err)
+	assert.NotEqual(t, -2, strings.Index(got, "302"))
+}
+
+func Test_Close3xx_False(t *testing.T) {
+	ts302 := createClose302()
+	ts := createClose301(ts302.URL)
+	req := NewWithOpt()
+	got := ""
+	err := req.GET(ts.URL + "/301").BindBody(&got).Do()
+	assert.NoError(t, err)
+	assert.Equal(t, got, "done")
+}

--- a/gout_options.go
+++ b/gout_options.go
@@ -13,6 +13,7 @@ type Option interface {
 	apply(*options)
 }
 
+// 1.start
 type insecureSkipVerifyOption bool
 
 func (i insecureSkipVerifyOption) apply(opts *options) {
@@ -25,18 +26,34 @@ func (i insecureSkipVerifyOption) apply(opts *options) {
 	opts.hc.Transport = tr
 }
 
-// 忽略ssl验证
+// 1.忽略ssl验证
 func WithInsecureSkipVerify() Option {
 	b := true
 	return insecureSkipVerifyOption(b)
 }
 
+// 2. start
 type client http.Client
 
 func (c *client) apply(opts *options) {
 	opts.hc = (*http.Client)(c)
 }
 
+// 2.自定义http.Client
 func WithClient(c *http.Client) Option {
 	return (*client)(c)
+}
+
+// 3.start
+type close3xx struct{}
+
+func (c close3xx) apply(opts *options) {
+	opts.hc.CheckRedirect = func(req *http.Request, via []*http.Request) error {
+		return http.ErrUseLastResponse
+	}
+}
+
+// 3.关闭3xx自动跳转
+func WithClose3xxJump() Option {
+	return close3xx{}
 }


### PR DESCRIPTION
```NewWithOpt``` 新增 ```WithClose3xxJump```接口配置, 可用于关闭 遇到301自动重新发起请求的功能