### PR TITLE
feat: set content-type only when it doesn't exist on user custom headers

### DIFF
--- a/dataflow/req.go
+++ b/dataflow/req.go
@@ -123,6 +123,10 @@ func (r *Req) addDefDebug() {
 }
 
 func (r *Req) addContextType(req *http.Request) {
+	if req.Header.Get("Content-Type") != "" {
+		return
+	}
+
 	if r.wwwForm != nil {
 		req.Header.Add("Content-Type", "application/x-www-form-urlencoded")
 	}

--- a/dataflow/req.go
+++ b/dataflow/req.go
@@ -318,7 +318,7 @@ func (r *Req) Request() (req *http.Request, err error) {
 		req.AddCookie(c)
 	}
 
-	if r.form != nil {
+	if r.form != nil && req.Header.Get("Content-Type") == "" {
 		req.Header.Add("Content-Type", f.FormDataContentType())
 	}
 


### PR DESCRIPTION
Hi @guonaihong 

When I use gout to send a JSON like the code below. 
```go
err = g.POST(url)
    .SetHeader(core.H{"Content-Type": "application/json"})
    .SetJSON("{\"key\":\"val\"}")
    .Do()
```
I found that the http headers gout sent likes this
```text
Content-Type: "application/json,application/json"
```

Then I investigated the source code and found that on this line https://github.com/guonaihong/gout/blob/511f37ce6e776ec33992618b645f71882e5526ba/dataflow/req.go#L331
gout adds `Content-Type` to headers whehter it exists or not. Which means if the user uses `SetHeader('Content-Type', 'xxx')` and `SetJSON()` in the same request. The `Content-Type` will have two values. Because the `Add` func called by `SetJSON` and `SetHeader` appends values to a key, not replace it. As the screenshot shows.

<img width="594" alt="image" src="https://github.com/guonaihong/gout/assets/1655036/03a72752-07be-4dca-96bc-476677b96093">


To avoid this situation. I believe we should check existence of `Content-Type` before setting it. And if the `Content-Type` exists, means users already set it by themeselves (for better visability or other purposes) or users want to use a different header value. gout shouldn't set it or replace it.